### PR TITLE
Fix for #59

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ cam-db-reasoned.jnl: noctua-reactome-ctd-models-ubergraph.jnl
 	cp $< $@ &&\
 	$(BLAZEGRAPH-RUNNER) reason --journal=$@ --properties=blazegraph.properties --reasoner=whelk --append-graph-name='#inferred' --ontology='http://reasoner.renci.org/ontology' --source-graphs-query=sparql/find-asserted-models.rq --direct-types=true
 
-ncbi-gene-classes.ttl: noctua-reactome-ctd-models.jnl
+ncbi-gene-classes.ttl: uniprot-to-ncbi-rules.ofn
 	$(BLAZEGRAPH-RUNNER) construct --journal=$< --properties=blazegraph.properties --outformat=turtle sparql/construct-ncbi-gene-classes.rq $@
 
 protein-subclasses.ttl: noctua-reactome-ctd-models.jnl sparql/construct-protein-subclasses.rq


### PR DESCRIPTION
Change the ncbi-gene-classes.ttl target to require only the uniprot-to-ncbi-rules.ofn as input