### PR TITLE
Update pipeline-tools version.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'phenoscape/pipeline-tools:v1.5.2'
+            image 'phenoscape/pipeline-tools:v1.5.3'
             label 'zeppo'
         }
     }


### PR DESCRIPTION
This pulls in a newer blazegraph-runner, which uses a newer whelk, which will provide more entity-to-entity inferences (e.g. https://github.com/NCATS-Tangerine/cam-kp-api/issues/254).