### PR TITLE
Update delete-non-production-models.ru

### DIFF
--- a/sparql/delete-non-production-models.ru
+++ b/sparql/delete-non-production-models.ru
@@ -11,9 +11,10 @@ WHERE {
     ?model rdf:type owl:Ontology .
     # A hacky way to choose Noctua model graphs
     ?model lego:modelstate ?modelstate .
-    FILTER(?modelstate != "production"^^xsd:string)
+    FILTER(?modelstate != "production")
+    FILTER NOT EXISTS{
     ?model <http://purl.org/pav/providedBy> ?provider .
-    FILTER(?provider != "https://reactome.org")
+    FILTER(?provider != "https://reactome.org")}
     GRAPH ?model {
      ?s ?p ?o .
     }


### PR DESCRIPTION
Fix that excludes models in development state with the exception of reactome models (https://github.com/NCATS-Tangerine/cam-pipeline/issues/70).